### PR TITLE
component has a bug where it doesn't specify the provider for reading GitHub API key

### DIFF
--- a/src/provider-github.tf
+++ b/src/provider-github.tf
@@ -51,6 +51,8 @@ data "aws_ssm_parameter" "github_api_key" {
   count           = !var.github_app_enabled ? 1 : 0
   name            = var.ssm_github_api_key
   with_decryption = true
+
+  provider = aws.config_secrets
 }
 
 # SSM Parameter for GitHub App Authentication
@@ -58,6 +60,8 @@ data "aws_ssm_parameter" "github_app_private_key" {
   count           = local.create_github_webhook && var.github_app_enabled ? 1 : 0
   name            = var.ssm_github_app_private_key
   with_decryption = true
+
+  provider = aws.config_secrets
 }
 
 # We will only need the github provider if we are creating the GitHub webhook with github_repository_webhook.


### PR DESCRIPTION
## what
* Consistent with codebase pattern: Other SSM parameter reads in data.tf and notifications.tf already use the same provider = aws.config_secrets pattern
* Proper provider alias: The aws.config_secrets provider is defined in provider-secrets.tf  and configured to access SSM parameters from a potentially different account/region
* Correct for secrets management: GitHub credentials should be read from the designated secrets store account, not the default provider region

## why
* The v2.2.0 component has a bug where it doesn't specify the provider for reading GitHub API key.
* Other SSM parameters (like OIDC, deploy keys, notifications) correctly use provider = aws.config_secrets, but the GitHub API key was missing this line.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of secret retrieval by explicitly using the correct configuration for secure parameters, reducing intermittent failures across environments.

- Chores
  - Standardized infrastructure configuration for fetching secrets to ensure consistency across accounts and regions. No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->