### PR TITLE
Fixed missing provider configuration for SSM data sources in the notifications module.

### DIFF
--- a/src/notifications.tf
+++ b/src/notifications.tf
@@ -2,6 +2,8 @@ data "aws_ssm_parameters_by_path" "argocd_notifications" {
   for_each        = local.notifications_notifiers_ssm_path
   path            = each.value
   with_decryption = true
+
+  provider = aws.config_secrets
 }
 
 data "aws_ssm_parameter" "slack_notifications" {
@@ -16,6 +18,8 @@ data "aws_ssm_parameter" "github_notifications_app_private_key" {
   count           = local.github_notifications_enabled && var.github_notifications_app_enabled ? 1 : 0
   name            = var.ssm_github_notifications_app_private_key
   with_decryption = true
+
+  provider = aws.config_secrets
 }
 
 module "notifications_templates" {


### PR DESCRIPTION
## what
- Added `provider = aws.config_secrets` to `data.aws_ssm_parameters_by_path.argocd_notifications`
- Added `provider = aws.config_secrets` to `data.aws_ssm_parameter.github_notifications_app_private_key`

## why
All encrypted SSM parameter data sources in this component should use the `aws.config_secrets` provider alias to enable cross-account access to the secrets store. 

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to explicitly scope notification services through the designated secret configuration provider for improved resource isolation and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->