### PR TITLE
fix: Do not leave a dangling comma if alb_logs_bucket == ""

### DIFF
--- a/src/resources/argocd-values.yaml.tpl
+++ b/src/resources/argocd-values.yaml.tpl
@@ -33,13 +33,14 @@ server:
       alb.ingress.kubernetes.io/backend-protocol: HTTPS
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80},{"HTTPS":443}]'
       alb.ingress.kubernetes.io/ssl-redirect: '443'
-      alb.ingress.kubernetes.io/load-balancer-attributes:
-            routing.http.drop_invalid_header_fields.enabled=true,
-%{ if alb_logs_bucket != "" ~}
-            access_logs.s3.enabled=true,
-            access_logs.s3.bucket=${alb_logs_bucket},
-            access_logs.s3.prefix=${alb_logs_prefix}
-%{ endif ~}
+      alb.ingress.kubernetes.io/load-balancer-attributes: ${join(",", concat(
+        ["routing.http.drop_invalid_header_fields.enabled=true"],
+        alb_logs_bucket != "" ? [
+          "access_logs.s3.enabled=true",
+          "access_logs.s3.bucket=${alb_logs_bucket}",
+          "access_logs.s3.prefix=${alb_logs_prefix}"
+        ] : []
+      ))}
 %{ if forecastle_enabled == true ~}
       forecastle.stakater.com/appName: "ArgoCD"
       forecastle.stakater.com/expose: "true"


### PR DESCRIPTION
## what

* Fix a configuration error in ArgoCD Helm chart templates where a dangling comma would be generated in the ALB load balancer attributes annotation when alb_logs_bucket is empty. The fix ensures valid YAML output for the ALB Ingress Controller.

## why
* We got this error when we use default configuration without alb_logs_bucket: `{"level":"info","ts":"2025-12-05T02:11:38Z","logger":"controllers.ingress","msg":"modifying loadBalancer attributes","stackID":"common","resourceID":"LoadBalancer","arn":"arn:aws:elasticloadbalancing:ap-southeast-2:654654259431:loadbalancer/app/k8s-common-3ca0ba6580/32093664f5e5c48d","change":{"routing.http.drop_invalid_header_fields.enabled":"true,"}}`.
Unfortunately, this error stopped the ALB controller for the whole cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced load balancer configuration architecture to use dynamic templating for improved flexibility in access logs setup and streamlined conditional configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->