### PR TITLE
Feat/internal alb and webhook ingress

### DIFF
--- a/src/github_webhook.tf
+++ b/src/github_webhook.tf
@@ -47,7 +47,10 @@ resource "github_repository_webhook" "default" {
   repository = each.value.repository
 
   configuration {
-    url          = format("%s/api/webhook", local.url)
+    # NOTE: local.webhook_url == "${local.url}/api/webhook" when var.webhook_ingress_enabled
+    # is false (the default), so existing deployments see no plan diff after upgrade. When
+    # opted in, this retargets the GitHub webhook to var.webhook_host without a new resource.
+    url          = local.webhook_url
     content_type = "json"
     secret       = local.webhook_github_secret
     insecure_ssl = false

--- a/src/main.tf
+++ b/src/main.tf
@@ -73,6 +73,12 @@ locals {
   host                              = var.host != "" ? var.host : format("%s.%s", var.name, local.regional_service_discovery_domain)
   url                               = format("https://%s", local.host)
 
+  # When webhook_ingress_enabled is false, webhook_host MUST equal local.host so that
+  # local.webhook_url collapses to the exact same string as `${local.url}/api/webhook`.
+  # This is the opt-in invariant: existing deployments see no plan diff after upgrade.
+  webhook_host = var.webhook_ingress_enabled ? coalesce(var.webhook_host, "argocd-webhook.${local.host}") : local.host
+  webhook_url  = format("https://%s/api/webhook", local.webhook_host)
+
   oidc_config_map = local.oidc_enabled ? {
     server : {
       config : {
@@ -168,6 +174,7 @@ module "argocd" {
         alb_logs_bucket            = var.alb_logs_bucket
         alb_logs_prefix            = var.alb_logs_prefix
         alb_name                   = var.alb_name == null ? "" : var.alb_name
+        alb_scheme                 = var.alb_scheme
         anonymous_enabled          = var.anonymous_enabled
         application_repos          = { for k, v in local.argocd_repositories : k => v.clone_url }
         argocd_host                = local.host
@@ -178,6 +185,7 @@ module "argocd" {
         github_deploy_keys_enabled = local.github_deploy_keys_enabled
         ingress_host               = local.host
         name                       = module.this.name
+        namespace                  = local.kubernetes_namespace
         oidc_enabled               = local.oidc_enabled
         oidc_rbac_scopes           = var.oidc_rbac_scopes
         rbac_default_policy        = var.argocd_rbac_default_policy
@@ -186,6 +194,10 @@ module "argocd" {
         saml_enabled               = local.saml_enabled
         saml_rbac_scopes           = var.saml_rbac_scopes
         service_type               = var.service_type
+        webhook_alb_group_name     = var.webhook_alb_group_name == null ? "" : var.webhook_alb_group_name
+        webhook_alb_scheme         = var.webhook_alb_scheme
+        webhook_host               = local.webhook_host
+        webhook_ingress_enabled    = var.webhook_ingress_enabled
       }
     ),
     # argocd-notifications specific settings

--- a/src/main.tf
+++ b/src/main.tf
@@ -76,8 +76,83 @@ locals {
   # When webhook_ingress_enabled is false, webhook_host MUST equal local.host so that
   # local.webhook_url collapses to the exact same string as `${local.url}/api/webhook`.
   # This is the opt-in invariant: existing deployments see no plan diff after upgrade.
-  webhook_host = var.webhook_ingress_enabled ? coalesce(var.webhook_host, "argocd-webhook.${local.host}") : local.host
+  #
+  # When enabled and webhook_host is unset, the fallback is rooted at the regional
+  # service discovery domain (NOT local.host) so the resulting FQDN sits one label
+  # below the regional zone. That matches a standard single-label wildcard ACM cert
+  # (`*.<regional-domain>`). Rooting at local.host instead would produce
+  # `argocd-webhook.argocd.<regional-domain>`, which a single-label wildcard does
+  # not cover.
+  webhook_host = var.webhook_ingress_enabled ? coalesce(var.webhook_host, "argocd-webhook.${local.regional_service_discovery_domain}") : local.host
   webhook_url  = format("https://%s/api/webhook", local.webhook_host)
+
+  # Public `/api/webhook` exposure requires the HMAC secret to exist in argocd-secret.
+  # If `github_webhook_enabled = false` the secret is never generated, so the
+  # ArgoCD webhook handler would accept ANY POST as valid (it only validates the
+  # signature when a secret is configured). Gate the public ingress on both flags
+  # to prevent an inadvertent unauthenticated DoS vector.
+  effective_webhook_ingress_enabled = var.webhook_ingress_enabled && local.github_webhook_enabled
+
+  # Build the path-restricted webhook Ingress in Terraform (not inside the values
+  # template) so it can be safely merged with a user-supplied
+  # `var.chart_values.extraObjects` list. Helm overlays arrays by replacement, so
+  # if we emitted `extraObjects` in the template AND the user emitted their own
+  # via `var.chart_values`, the user's would silently replace ours and the
+  # webhook ingress would never get created.
+  webhook_ingress_extra_objects = local.effective_webhook_ingress_enabled ? [
+    {
+      apiVersion = "networking.k8s.io/v1"
+      kind       = "Ingress"
+      metadata = {
+        name      = "${module.this.name}-server-webhook"
+        namespace = local.kubernetes_namespace
+        annotations = merge(
+          length(coalesce(var.webhook_alb_group_name, "")) > 0 ? {
+            "alb.ingress.kubernetes.io/group.name" = var.webhook_alb_group_name
+          } : {},
+          {
+            "alb.ingress.kubernetes.io/scheme"                   = var.webhook_alb_scheme
+            "alb.ingress.kubernetes.io/backend-protocol"         = "HTTPS"
+            "alb.ingress.kubernetes.io/listen-ports"             = jsonencode([{ HTTPS = 443 }])
+            "alb.ingress.kubernetes.io/ssl-redirect"             = "443"
+            "alb.ingress.kubernetes.io/load-balancer-attributes" = "routing.http.drop_invalid_header_fields.enabled=true"
+            "external-dns.alpha.kubernetes.io/hostname"          = local.webhook_host
+            "external-dns.alpha.kubernetes.io/ttl"               = "60"
+          }
+        )
+      }
+      spec = {
+        ingressClassName = var.webhook_ingress_class_name
+        tls = [{
+          hosts = [local.webhook_host]
+        }]
+        rules = [{
+          host = local.webhook_host
+          http = {
+            paths = [{
+              path     = "/api/webhook"
+              pathType = "Exact"
+              backend = {
+                service = {
+                  name = "${module.this.name}-server"
+                  port = { name = "https" }
+                }
+              }
+            }]
+          }
+        }]
+      }
+    }
+  ] : []
+
+  # Merge our webhook Ingress with any user-supplied chart_values.extraObjects so
+  # both lists land in the final rendered values block instead of clobbering.
+  merged_chart_values = length(local.webhook_ingress_extra_objects) > 0 ? merge(var.chart_values, {
+    extraObjects = concat(
+      try(var.chart_values.extraObjects, []),
+      local.webhook_ingress_extra_objects
+    )
+  }) : var.chart_values
 
   oidc_config_map = local.oidc_enabled ? {
     server : {
@@ -171,6 +246,7 @@ module "argocd" {
       {
         admin_enabled              = var.admin_enabled
         alb_group_name             = var.alb_group_name == null ? "" : var.alb_group_name
+        alb_ingress_class_name     = var.alb_ingress_class_name
         alb_logs_bucket            = var.alb_logs_bucket
         alb_logs_prefix            = var.alb_logs_prefix
         alb_name                   = var.alb_name == null ? "" : var.alb_name
@@ -185,7 +261,6 @@ module "argocd" {
         github_deploy_keys_enabled = local.github_deploy_keys_enabled
         ingress_host               = local.host
         name                       = module.this.name
-        namespace                  = local.kubernetes_namespace
         oidc_enabled               = local.oidc_enabled
         oidc_rbac_scopes           = var.oidc_rbac_scopes
         rbac_default_policy        = var.argocd_rbac_default_policy
@@ -194,11 +269,6 @@ module "argocd" {
         saml_enabled               = local.saml_enabled
         saml_rbac_scopes           = var.saml_rbac_scopes
         service_type               = var.service_type
-        webhook_alb_group_name     = var.webhook_alb_group_name == null ? "" : var.webhook_alb_group_name
-        webhook_alb_scheme         = var.webhook_alb_scheme
-        webhook_host               = local.webhook_host
-        webhook_ingress_class_name = var.webhook_ingress_class_name
-        webhook_ingress_enabled    = var.webhook_ingress_enabled
       }
     ),
     # argocd-notifications specific settings
@@ -215,7 +285,7 @@ module "argocd" {
       local.oidc_config_map,
       local.saml_config_map,
     )),
-    yamlencode(var.chart_values)
+    yamlencode(local.merged_chart_values)
   ])
 
   context = module.this.context

--- a/src/main.tf
+++ b/src/main.tf
@@ -145,14 +145,27 @@ locals {
     }
   ] : []
 
-  # Merge our webhook Ingress with any user-supplied chart_values.extraObjects so
-  # both lists land in the final rendered values block instead of clobbering.
-  merged_chart_values = length(local.webhook_ingress_extra_objects) > 0 ? merge(var.chart_values, {
+  # Render our webhook Ingress as a SEPARATE Helm values document that comes
+  # AFTER `var.chart_values` in the values list. Helm overlays arrays by
+  # replacement, so we explicitly concat any user-supplied
+  # `chart_values.extraObjects` with our webhook Ingress and emit the combined
+  # list as the last value document — last-wins semantics keep both sides.
+  #
+  # When the webhook is disabled this resolves to an empty string and is
+  # dropped by `compact()`, so `var.chart_values` is the final word and
+  # default-config consumers see zero rendered-values diff.
+  #
+  # Using a conditional yamlencode (instead of a conditional `merge()` of
+  # var.chart_values) avoids Terraform's "inconsistent conditional result
+  # types" error — both branches of the ternary here are `string`, whereas
+  # `merge(var.chart_values, {extraObjects = ...})` vs `var.chart_values`
+  # produces objects with different attribute schemas.
+  webhook_chart_values_supplement = length(local.webhook_ingress_extra_objects) > 0 ? yamlencode({
     extraObjects = concat(
       try(var.chart_values.extraObjects, []),
       local.webhook_ingress_extra_objects
     )
-  }) : var.chart_values
+  }) : ""
 
   oidc_config_map = local.oidc_enabled ? {
     server : {
@@ -285,7 +298,8 @@ module "argocd" {
       local.oidc_config_map,
       local.saml_config_map,
     )),
-    yamlencode(local.merged_chart_values)
+    yamlencode(var.chart_values),
+    local.webhook_chart_values_supplement,
   ])
 
   context = module.this.context

--- a/src/main.tf
+++ b/src/main.tf
@@ -107,7 +107,7 @@ locals {
         name      = "${module.this.name}-server-webhook"
         namespace = local.kubernetes_namespace
         annotations = merge(
-          length(coalesce(var.webhook_alb_group_name, "")) > 0 ? {
+          var.webhook_alb_group_name != null && var.webhook_alb_group_name != "" ? {
             "alb.ingress.kubernetes.io/group.name" = var.webhook_alb_group_name
           } : {},
           {

--- a/src/main.tf
+++ b/src/main.tf
@@ -197,6 +197,7 @@ module "argocd" {
         webhook_alb_group_name     = var.webhook_alb_group_name == null ? "" : var.webhook_alb_group_name
         webhook_alb_scheme         = var.webhook_alb_scheme
         webhook_host               = local.webhook_host
+        webhook_ingress_class_name = var.webhook_ingress_class_name
         webhook_ingress_enabled    = var.webhook_ingress_enabled
       }
     ),

--- a/src/resources/argocd-values.yaml.tpl
+++ b/src/resources/argocd-values.yaml.tpl
@@ -149,6 +149,11 @@ applicationSet:
 # still need a public endpoint. ArgoCD validates the HMAC signature against
 # `webhook.github.secret` in argocd-secret, so the public surface is one POST endpoint
 # that rejects unsigned/invalid requests.
+#
+# NOTE: when the cluster's IngressClassParams for this class hardcodes group.name/scheme,
+# those values override the per-Ingress annotations below. Use webhook_ingress_class_name
+# to select an IngressClass whose IngressClassParams don't override (or set an empty group)
+# if you need the annotations to take effect.
 extraObjects:
   - apiVersion: networking.k8s.io/v1
     kind: Ingress
@@ -167,7 +172,7 @@ extraObjects:
         external-dns.alpha.kubernetes.io/hostname: ${webhook_host}
         external-dns.alpha.kubernetes.io/ttl: "60"
     spec:
-      ingressClassName: alb
+      ingressClassName: ${webhook_ingress_class_name}
       tls:
         - hosts:
             - ${webhook_host}

--- a/src/resources/argocd-values.yaml.tpl
+++ b/src/resources/argocd-values.yaml.tpl
@@ -29,7 +29,7 @@ server:
 %{ if alb_name != "" ~}
       alb.ingress.kubernetes.io/load-balancer-name: ${alb_name}
 %{ endif ~}
-      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/scheme: ${alb_scheme}
       alb.ingress.kubernetes.io/backend-protocol: HTTPS
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80},{"HTTPS":443}]'
       alb.ingress.kubernetes.io/ssl-redirect: '443'
@@ -142,3 +142,44 @@ repoServer:
 
 applicationSet:
   replicas: 2
+
+%{ if webhook_ingress_enabled ~}
+# Path-restricted Ingress exposing only /api/webhook on a separate ALB/host.
+# Use case: main argocd-server Ingress is internal-scheme but GitHub push webhooks
+# still need a public endpoint. ArgoCD validates the HMAC signature against
+# `webhook.github.secret` in argocd-secret, so the public surface is one POST endpoint
+# that rejects unsigned/invalid requests.
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ${name}-server-webhook
+      namespace: ${namespace}
+      annotations:
+%{ if webhook_alb_group_name != "" ~}
+        alb.ingress.kubernetes.io/group.name: ${webhook_alb_group_name}
+%{ endif ~}
+        alb.ingress.kubernetes.io/scheme: ${webhook_alb_scheme}
+        alb.ingress.kubernetes.io/backend-protocol: HTTPS
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+        alb.ingress.kubernetes.io/ssl-redirect: '443'
+        alb.ingress.kubernetes.io/load-balancer-attributes: routing.http.drop_invalid_header_fields.enabled=true
+        external-dns.alpha.kubernetes.io/hostname: ${webhook_host}
+        external-dns.alpha.kubernetes.io/ttl: "60"
+    spec:
+      ingressClassName: alb
+      tls:
+        - hosts:
+            - ${webhook_host}
+      rules:
+        - host: ${webhook_host}
+          http:
+            paths:
+              - path: /api/webhook
+                pathType: Exact
+                backend:
+                  service:
+                    name: ${name}-server
+                    port:
+                      name: https
+%{ endif ~}

--- a/src/resources/argocd-values.yaml.tpl
+++ b/src/resources/argocd-values.yaml.tpl
@@ -18,7 +18,7 @@ server:
 
   ingress:
     enabled: true
-    ingressClassName: alb
+    ingressClassName: ${alb_ingress_class_name}
     annotations:
       cert-manager.io/cluster-issuer: ${cert_issuer}
       external-dns.alpha.kubernetes.io/hostname: ${ingress_host}
@@ -142,49 +142,3 @@ repoServer:
 
 applicationSet:
   replicas: 2
-
-%{ if webhook_ingress_enabled ~}
-# Path-restricted Ingress exposing only /api/webhook on a separate ALB/host.
-# Use case: main argocd-server Ingress is internal-scheme but GitHub push webhooks
-# still need a public endpoint. ArgoCD validates the HMAC signature against
-# `webhook.github.secret` in argocd-secret, so the public surface is one POST endpoint
-# that rejects unsigned/invalid requests.
-#
-# NOTE: when the cluster's IngressClassParams for this class hardcodes group.name/scheme,
-# those values override the per-Ingress annotations below. Use webhook_ingress_class_name
-# to select an IngressClass whose IngressClassParams don't override (or set an empty group)
-# if you need the annotations to take effect.
-extraObjects:
-  - apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      name: ${name}-server-webhook
-      namespace: ${namespace}
-      annotations:
-%{ if webhook_alb_group_name != "" ~}
-        alb.ingress.kubernetes.io/group.name: ${webhook_alb_group_name}
-%{ endif ~}
-        alb.ingress.kubernetes.io/scheme: ${webhook_alb_scheme}
-        alb.ingress.kubernetes.io/backend-protocol: HTTPS
-        alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
-        alb.ingress.kubernetes.io/ssl-redirect: '443'
-        alb.ingress.kubernetes.io/load-balancer-attributes: routing.http.drop_invalid_header_fields.enabled=true
-        external-dns.alpha.kubernetes.io/hostname: ${webhook_host}
-        external-dns.alpha.kubernetes.io/ttl: "60"
-    spec:
-      ingressClassName: ${webhook_ingress_class_name}
-      tls:
-        - hosts:
-            - ${webhook_host}
-      rules:
-        - host: ${webhook_host}
-          http:
-            paths:
-              - path: /api/webhook
-                pathType: Exact
-                backend:
-                  service:
-                    name: ${name}-server
-                    port:
-                      name: https
-%{ endif ~}

--- a/src/variables-argocd.tf
+++ b/src/variables-argocd.tf
@@ -225,3 +225,66 @@ variable "github_deploy_keys_enabled" {
   Alternatively, you can use a GitHub App to access this desired state repository configured with `var.github_app_enabled`, `var.github_app_id`, and `var.github_app_installation_id`.
   EOT
 }
+
+variable "alb_scheme" {
+  type        = string
+  default     = "internet-facing"
+  description = <<-EOT
+  Scheme of the ALB fronting the argocd-server Ingress. One of `internet-facing` or `internal`.
+
+  Use `internal` when argocd should only be reachable from inside the VPC (e.g. via VPN or
+  a private connectivity mesh). When combined with `var.webhook_ingress_enabled`, the
+  primary UI/API moves internal while `/api/webhook` stays reachable on a separate Ingress.
+  EOT
+
+  validation {
+    condition     = contains(["internet-facing", "internal"], var.alb_scheme)
+    error_message = "alb_scheme must be \"internet-facing\" or \"internal\"."
+  }
+}
+
+variable "webhook_ingress_enabled" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  Provision a second, path-restricted Ingress exposing only `/api/webhook` on a separate
+  ALB and hostname.
+
+  Intended use: when `var.alb_scheme` is `internal` (argocd UI on a private ALB), GitHub
+  push webhooks can't reach the cluster. Enabling this creates a minimal public Ingress
+  matching only `Host: <var.webhook_host>` AND `Path: /api/webhook`, so the GitHub webhook
+  endpoint stays reachable while the rest of the API/UI does not.
+
+  The component's GitHub webhook resource (`github_repository_webhook.default`) automatically
+  retargets to the new hostname when this is `true`.
+  EOT
+}
+
+variable "webhook_alb_group_name" {
+  type        = string
+  default     = null
+  description = "ALB group name annotation for the webhook-only Ingress. Typically the existing internet-facing ingress group. Required when `var.webhook_ingress_enabled` is `true`."
+}
+
+variable "webhook_alb_scheme" {
+  type        = string
+  default     = "internet-facing"
+  description = "Scheme for the webhook-only Ingress's ALB. Almost always `internet-facing` (the whole point is to expose `/api/webhook` to GitHub)."
+
+  validation {
+    condition     = contains(["internet-facing", "internal"], var.webhook_alb_scheme)
+    error_message = "webhook_alb_scheme must be \"internet-facing\" or \"internal\"."
+  }
+}
+
+variable "webhook_host" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  FQDN for the webhook-only Ingress. If `null` (default) and `var.webhook_ingress_enabled`
+  is `true`, falls back to `argocd-webhook.<var.host or generated host>`.
+
+  Must resolve to the ALB selected by `var.webhook_alb_group_name`, and the ALB's listener
+  must have a TLS certificate that covers this hostname.
+  EOT
+}

--- a/src/variables-argocd.tf
+++ b/src/variables-argocd.tf
@@ -263,13 +263,27 @@ variable "webhook_ingress_enabled" {
 variable "webhook_alb_group_name" {
   type        = string
   default     = null
-  description = "ALB group name annotation for the webhook-only Ingress. Typically the existing internet-facing ingress group. Required when `var.webhook_ingress_enabled` is `true`."
+  description = <<-EOT
+  ALB group name annotation (`alb.ingress.kubernetes.io/group.name`) for the
+  webhook-only Ingress. Optional — when null/empty, the annotation is omitted
+  and the controller falls back to its default (per IngressClass + cluster
+  IngressClassParams configuration).
+
+  Note: if the chosen IngressClass's IngressClassParams sets a `group.name`,
+  that value takes precedence over this annotation (AWS LBC precedence rule).
+  EOT
 }
 
 variable "webhook_alb_scheme" {
   type        = string
   default     = "internet-facing"
-  description = "Scheme for the webhook-only Ingress's ALB. Almost always `internet-facing` (the whole point is to expose `/api/webhook` to GitHub)."
+  description = <<-EOT
+  Scheme annotation (`alb.ingress.kubernetes.io/scheme`) for the webhook-only Ingress.
+  Almost always `internet-facing` (the whole point is to expose `/api/webhook` to GitHub).
+
+  Note: if the chosen IngressClass's IngressClassParams sets `scheme`, that
+  value takes precedence over this annotation (AWS LBC precedence rule).
+  EOT
 
   validation {
     condition     = contains(["internet-facing", "internal"], var.webhook_alb_scheme)
@@ -285,6 +299,28 @@ variable "webhook_host" {
   is `true`, falls back to `argocd-webhook.<var.host or generated host>`.
 
   Must resolve to the ALB selected by `var.webhook_alb_group_name`, and the ALB's listener
-  must have a TLS certificate that covers this hostname.
+  must have a TLS certificate that covers this hostname. An empty string is rejected.
   EOT
+
+  validation {
+    condition     = var.webhook_host == null || length(var.webhook_host) > 0
+    error_message = "webhook_host must be either null or a non-empty FQDN."
+  }
+}
+
+variable "webhook_ingress_class_name" {
+  type        = string
+  default     = "alb"
+  description = <<-EOT
+  IngressClass name (`spec.ingressClassName`) on the webhook-only Ingress.
+  Defaults to `alb`. Change this when the default `alb` IngressClass's
+  IngressClassParams hardcodes `group.name`/`scheme` values that override
+  `var.webhook_alb_group_name`/`var.webhook_alb_scheme` and you need a class
+  whose params don't.
+  EOT
+
+  validation {
+    condition     = length(var.webhook_ingress_class_name) > 0
+    error_message = "webhook_ingress_class_name must not be an empty string."
+  }
 }

--- a/src/variables-argocd.tf
+++ b/src/variables-argocd.tf
@@ -230,16 +230,37 @@ variable "alb_scheme" {
   type        = string
   default     = "internet-facing"
   description = <<-EOT
-  Scheme of the ALB fronting the argocd-server Ingress. One of `internet-facing` or `internal`.
+  Scheme annotation (`alb.ingress.kubernetes.io/scheme`) on the main argocd-server
+  Ingress. One of `internet-facing` or `internal`.
 
-  Use `internal` when argocd should only be reachable from inside the VPC (e.g. via VPN or
-  a private connectivity mesh). When combined with `var.webhook_ingress_enabled`, the
-  primary UI/API moves internal while `/api/webhook` stays reachable on a separate Ingress.
+  Note: this is only the per-Ingress annotation. If the IngressClass selected by
+  `var.alb_ingress_class_name` has an `IngressClassParams` that hardcodes `scheme`,
+  that value takes precedence over this annotation per AWS LB Controller precedence
+  rules. To actually move ArgoCD onto an internal ALB, set BOTH `alb_scheme = "internal"`
+  AND `alb_ingress_class_name` to an IngressClass whose IngressClassParams don't
+  override the scheme (or do enforce `internal`).
   EOT
 
   validation {
     condition     = contains(["internet-facing", "internal"], var.alb_scheme)
     error_message = "alb_scheme must be \"internet-facing\" or \"internal\"."
+  }
+}
+
+variable "alb_ingress_class_name" {
+  type        = string
+  default     = "alb"
+  description = <<-EOT
+  IngressClass name (`spec.ingressClassName`) on the main argocd-server Ingress.
+  Defaults to `alb`. Set to a different IngressClass when the default `alb`
+  IngressClass's IngressClassParams hardcodes `group.name`/`scheme` values that
+  override `var.alb_group_name`/`var.alb_scheme` and you need a class whose
+  params don't.
+  EOT
+
+  validation {
+    condition     = length(var.alb_ingress_class_name) > 0
+    error_message = "alb_ingress_class_name must not be an empty string."
   }
 }
 
@@ -257,6 +278,12 @@ variable "webhook_ingress_enabled" {
 
   The component's GitHub webhook resource (`github_repository_webhook.default`) automatically
   retargets to the new hostname when this is `true`.
+
+  Requires `var.github_webhook_enabled = true` so the HMAC secret used to validate
+  `/api/webhook` payloads is generated — without it, ArgoCD's webhook handler accepts
+  any POST and triggers a sync, which would make the public endpoint an unauthenticated
+  DoS surface. When `github_webhook_enabled = false`, the public Ingress is silently
+  skipped.
   EOT
 }
 
@@ -296,7 +323,9 @@ variable "webhook_host" {
   default     = null
   description = <<-EOT
   FQDN for the webhook-only Ingress. If `null` (default) and `var.webhook_ingress_enabled`
-  is `true`, falls back to `argocd-webhook.<var.host or generated host>`.
+  is `true`, falls back to `argocd-webhook.<regional_service_discovery_domain>` (one
+  label below the regional zone, so a standard single-label wildcard ACM cert covers
+  it).
 
   Must resolve to the ALB selected by `var.webhook_alb_group_name`, and the ALB's listener
   must have a TLS certificate that covers this hostname. An empty string is rejected.


### PR DESCRIPTION
## what
* Add the ability to use an internal ALB for ArgoCD
* Add the public webhook receiver when using an internal ALB

## why
* We want to access ArgoCD only through company's Zero Trust solution
* We still want webhooks to work

## references




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional dedicated webhook ingress separate from the main Argo CD ingress with path-scoped routing for /api/webhook and automatic webhook retargeting when enabled.
  * Configurable ALB scheme and ingress class for both main and webhook traffic (internet-facing or internal).
  * Ability to specify a custom webhook hostname; by default the existing webhook URL is preserved unless webhook ingress is enabled.
  * Helm values now append generated ingress objects as a supplement so webhook objects are included when enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse-terraform-components/aws-eks-argocd/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->